### PR TITLE
Zac youth mentor branch merge to main

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/BBcode/CompetitionTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/BBcode/CompetitionTeleOp.java
@@ -120,7 +120,7 @@ public class CompetitionTeleOp extends LinearOpMode{
 
     GoBildaPinpointDriverRR odo; // Declare OpMode member for the Odometry Computer
     public double xOffset = -7.002384767061902; //RRTune, -6.5; measured
-    public double yOffset = -1.2229245167313665;
+    public double yOffset = -4.7; // -1.2229245167313665;
     @Override
     public void runOpMode() throws InterruptedException{
         // Initialization Code Goes Here

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/BBcode/CompetitionTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/BBcode/CompetitionTeleOp.java
@@ -119,19 +119,11 @@ public class CompetitionTeleOp extends LinearOpMode{
     }
 
     GoBildaPinpointDriverRR odo; // Declare OpMode member for the Odometry Computer
-    public double xOffset = -7.002384767061902; //RRTune, -6.5; measured
-    public double yOffset = -4.7; // -1.2229245167313665;
     @Override
     public void runOpMode() throws InterruptedException{
         // Initialization Code Goes Here
         ChristmasLight _christmasLight = new ChristmasLight(this);
         odo = hardwareMap.get(GoBildaPinpointDriverRR.class,"pinpoint");
-        GoBildaPinpointDriver.EncoderDirection xDirection = GoBildaPinpointDriver.EncoderDirection.REVERSED;
-        GoBildaPinpointDriver.EncoderDirection yDirection = GoBildaPinpointDriver.EncoderDirection.REVERSED;
-        double encoderResolution = GoBildaPinpointDriverRR.goBILDA_4_BAR_POD;
-        odo.setOffsets(DistanceUnit.MM.fromInches(xOffset), DistanceUnit.MM.fromInches(yOffset));
-        odo.setEncoderResolution(encoderResolution);
-        odo.setEncoderDirections(xDirection, yDirection);
         odo.resetPosAndIMU();
 
         //Init limelight

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointDrive.java
@@ -33,7 +33,7 @@ public class PinpointDrive extends MecanumDrive {
         //These are tuned for 3110-0002-0001 Product Insight #1
         // RR localizer note: These units are inches, presets are converted from mm (which is why they are inexact)
         public double xOffset = -6.693; //RRTune, -6.5; measured
-        public double yOffset = -1.575;
+        public double yOffset = -4.7; //-1.575;
 
         /*
         Set the kind of pods used by your robot. If you're using goBILDA odometry pods, select either

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointDrive.java
@@ -53,7 +53,7 @@ public class PinpointDrive extends MecanumDrive {
         you move the robot to the left.
          */
         public GoBildaPinpointDriver.EncoderDirection xDirection = GoBildaPinpointDriver.EncoderDirection.REVERSED;
-        public GoBildaPinpointDriver.EncoderDirection yDirection = GoBildaPinpointDriver.EncoderDirection.REVERSED;
+        public GoBildaPinpointDriver.EncoderDirection yDirection = GoBildaPinpointDriver.EncoderDirection.FORWARD;
     }
 
     public static Params PARAMS2 = new Params();


### PR DESCRIPTION
This is Zac, your friendly youth mentor.

Matthew and I found that the pinpoint y pod was reversed so he corrected it. This solved the auto issue, but led to lots of wierd issues when running CompetitionTeleOp. Matthew decided to take a break so I started reading through both of the programs, while i didnt understand all of the code, i noticed that the pinpoint controller was being forced to change its parametersto be different than the object when first initialized. Even though this may not be an issue i tested the CompetitionTeleOp with those lines commented out(the lines setting direction and offsets of odo pods), and it worked beautifully.

As it worked great for both teleOp auto movements and the sample/specimen autos, i recommend turning this into main to use it as a stepping stone for the teams next steps.

Along the idea of next steps, i recommend tuning road runner in the most basic way following the rr.brott.dev website through the idea of using 2 wheel odo and when doing so not touching or editing any of the pinpoint class.

My opinion: Don't touch the pinpoint class for the rest of the season unless an odo pod is moved or yall get a new pinpoint. It is set to +- .1 in for offsets and works in teleOp and auto.